### PR TITLE
wasm index.html little fix and questions

### DIFF
--- a/build/wasm/linux/build.sh
+++ b/build/wasm/linux/build.sh
@@ -1,0 +1,2 @@
+docker build ../../.. -f Dockerfile -t magick-wasm-linux
+docker run -it -v $PWD/output:/output -w /Magick.Native magick-wasm-linux /build/copy.Native.sh /output

--- a/build/wasm/linux/output/index.html
+++ b/build/wasm/linux/output/index.html
@@ -8,6 +8,8 @@
     <div>
         <div style="float: left;padding-right: 2pt">Delegates:</div>
         <div id="delegates"></div>
+        <div style="float: left;padding-right: 2pt">Features:</div>
+        <div id="features"></div>
     </div>
 
     <script type="text/javascript" src="magick-Q8.js"></script>
@@ -27,10 +29,10 @@
         
         Module.onRuntimeInitialized = function()
         {
-            console.log(Module);
-            const version = document.getElementById('version');
-            version.innerText = getString(Module._MagickNET_ImageMagickVersion_Get());
-            delegates.innerText = getString(Module._MagickNET_Delegates_Get());
+            const address = Module._Magick_Delegates_Get()
+            document.getElementById('version').innerText = 'Quantum Depth: ' + Module._Quantum_Depth_Get();
+            document.getElementById('delegates').innerText = getString(Module._Magick_Delegates_Get());
+            document.getElementById('features').innerText =  getString(Module._Magick_Features_Get());
         }
 
     </script>

--- a/build/wasm/linux/output/index.html
+++ b/build/wasm/linux/output/index.html
@@ -29,7 +29,6 @@
         
         Module.onRuntimeInitialized = function()
         {
-            const address = Module._Magick_Delegates_Get()
             document.getElementById('version').innerText = 'Quantum Depth: ' + Module._Quantum_Depth_Get();
             document.getElementById('delegates').innerText = getString(Module._Magick_Delegates_Get());
             document.getElementById('features').innerText =  getString(Module._Magick_Features_Get());


### PR DESCRIPTION
Thanks for the project. now wasm/linux/output/index.html prints
```
Quantum Depth: 8
Delegates:freetype heic jng jp2 jpeg lcms png raw tiff webp xml zlib
Features:Cipher
```
 Didn't find a way to get the version since I'm unfamiliar with IM APIs and seems that some methods are missing. 

thanks for this project, although I couldn't make it work as I want, I learn I took many tips for my emscripten port / JS library https://github.com/cancerberoSgx/magica  on which I'm archiving good "real-time" results in the browser & canvas (demo https://cancerberosgx.github.io/demos/magica/canvas/ - more details in the forum https://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=36526&sid=bed632a56b36f2d5875d1aae399579bf) 

I have a question for you. I'm actually not using Magick.Native in my emscripten build and I wonder:

  1) does it give any benefit for apps running in the browser ? what about node.js ? (I'm sorry for the ignorance, I know it has to do with low-level devices integration, an example would be awesome)
  2) Does it have any hard dependency ? For example currently I'm not including libxml, libheif,,libde265, nor jpegturbo (the rest I'm)
  3) How can I verify it's part of the features / delegates ? is there some label / on features / delegates output ? 

Second and important, in my library I was able to integrate **libfftw** https://github.com/cancerberoSgx/magica/blob/master/magick-wasm/build/emscripten-scripts/build-fftw.sh (fourier) - would you accept a PR with that one ? They don't have a git or any other version control - so my script has to download a .zip from their CDN whcih I don't know if that's acceptable for you ? And the same for **potrace** .bitmap->svg ?

Finally, this project of mine (https://github.com/cancerberoSgx/magica) has high level JS / TS API and is able to consume not only my own .wasm builds but also wasm-imagemagick's project since it relies on executing IM Command line `magick` by calling it as Module.main(). So by just building IM utilities and biding executable I can call a compatible Module.main. Since your build is different from mine and the other, and since my project has lots of tests (new tests in JS running in node.js and browser, and some performance benchmarks too) I would like to add support for utilities here too to have a third build. 

For each feature/delegate/API  added I tried to add some tests. Now i'm implementing preconditions so they don't blindly fail if the current build doesn't support a format or feature 
 (so I can run against even builds with no libraries at all) 

I wonder what do you think about, when the moment comes, discuss a PR with this new 'utilities' build in your project . IMO is unlikely JS users to call the current API like it's now and more likely to use Module.main(['convert', ...]) etc - it's hard but the CLI is more familiar. Also if this project take cares of the build is one less job for me :)

Thanks! and sorry for the long post,  Keep it up

