### PR TITLE
Remove Line Break from License

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
This is a very minor change, but I noticed GitHub is failing to detect the license of the project.

![image](https://user-images.githubusercontent.com/22801583/106674704-0b1e8400-65b4-11eb-8337-368f8e44a074.png)
> This project currently

vs

![image](https://user-images.githubusercontent.com/22801583/106674767-2e493380-65b4-11eb-854f-faa063332315.png)
> What it should say

Presumably it's because of the line break at the top which is screwing GitHub.

A bit odd though since the license as provided at https://www.apache.org/licenses/LICENSE-2.0.txt includes that line break at the top, so I feel it should be acceptable. :thinking: 