### PR TITLE
Don't run Upload NuGet package on Pull Requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -499,6 +499,7 @@ jobs:
       working-directory: publish/dotnet
 
     - name: Upload NuGet package
+      if: ${{ github.event_name != 'pull_request' }}
       working-directory: publish/dotnet
       run: |
         dotnet tool install gpr -g


### PR DESCRIPTION
> Reminder for myself that I will need to make sure the build works in a PR. The publishing of the package to the gpr should be skipped.
> p.s. Feel free to pick this up.
> \- https://github.com/dlemstra/Magick.Native/pull/9#issuecomment-772342323

Decided to see if I could indeed pick it up, peeked at the GitHub Action docs and added a condition so the "Upload NuGet package" step is only executed if it's not a pull request.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif

---

If for whatever reason this is done incorrectly, you can just treat this as your reminder instead of merging. ^-^'