### PR TITLE
Add a verify workflow for MacOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,7 @@ jobs:
     - name: Upload library
       uses: actions/upload-artifact@v3
       with:
-        name: macos
+        name: macos-x64
         path: artifacts
 
   macos_arm64:
@@ -575,6 +575,32 @@ jobs:
         export path=$(pwd)
         docker run -v $path:/Magick.Native mcr.microsoft.com/dotnet/sdk:6.0-focal-arm64v8 Magick.Native/build/shared/verify.Native.sh linux arm64 /Magick.Native OpenMP
 
+  verify_macos:
+    name: 'Verify MacOS'
+    needs:
+      - macos
+      - macos_arm64
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+        arch: [x64, arm64]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+
+    - name: Download macos library
+      uses: actions/download-artifact@v3
+      with:
+        name: macos-${{ matrix.arch }}
+
+    - name: Verify MacOS
+      run: build/shared/verify.Native.MacOS.sh macos ${{ matrix.arch }} . 
+
   metadata:
     name: 'Metadata'
     needs:
@@ -584,8 +610,7 @@ jobs:
       - verify_linux_musl_openmp
       - verify_linux_arm64
       - verify_linux_arm64_openmp
-      - macos
-      - macos_arm64
+      - verify_macos
       - windows
       - wasm
     runs-on: windows-latest
@@ -653,7 +678,7 @@ jobs:
     - name: Download macos library
       uses: actions/download-artifact@v3
       with:
-        name: macos
+        name: macos-x64
         path: publish\dotnet\files\macos
 
     - name: Download macos arm64 library

--- a/build/shared/verify.Native.MacOS.sh
+++ b/build/shared/verify.Native.MacOS.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+config=$1
+arch=$2
+folder=$3
+
+SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+. $SCRIPT_PATH/../$config-$arch/settings.sh
+
+
+verifyNative() {
+    local name=$1
+
+    local file=${folder}/Release${name}/$arch/Magick.Native-${name}-$arch.dll.$EXTENSION
+
+    if [ ! -f $file ]; then
+        echo "Unable to find $file"
+        exit 1
+    fi
+
+    ld_arch=$arch
+    if [ $ld_arch == "x64" ]; then
+        ld_arch="x86_64"
+    fi
+    exit_code=0
+    output=$(lipo -info $file 2>&1) || exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "Failed to execute lipo: $output"
+        exit 1
+    fi
+
+    if echo "$output" | grep "is architecture: $ld_arch"; then
+        echo "Verified architecture $file"
+    else
+        echo "Unexpected architecture for $file"
+        echo $output
+        exit 1
+    fi
+
+    macos_version=$(sw_vers -productVersion)
+    # When specifying a platform version to ld, an error occurs, and so we need to specify the path to the
+    # system shared libraries to apply -lSystem
+    sdk_link="-L$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib -lSystem"
+    # clang-ld requires a `main` function, so we tell it that it's expected to be undefined with -U
+    output=$(ld $file -arch $ld_arch -platform_version macos $macos_version $macos_version -U _main $sdk_link 2>&1) || exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "Failed to execute ld: $output"
+        exit 1
+    fi
+
+    if echo "$output" | grep "Undefined symbols for architecture"; then
+        exit 1
+    else
+        echo "Verified ld status for $file"
+    fi
+}
+
+for quantum in ${QUANTUMS[@]}; do
+    verifyNative $quantum
+done
+


### PR DESCRIPTION
This adds another step to the workflow to verify the built macos shared libraries.
While we build only on the macos-11 runner, I added a matrix to test this on both macos 11 and 12, though we can decide if this is necessary to do or if we only need one.

I ended up performing two tests:
* Use `lipo` to see if the declared architecture of the file is correct
* Use `ld` to "link" the shared library to an executable, to check that it can be compiled

I didn't do the equivalent of the linux verify's `ldd` step, as the macos tools for checking linked libraries don't show that a library is missing until you run it (using the zstd binary as an example here):

```
mv /usr/local/lib/libzstd.1.dylib /usr/local/lib/libzstd.1.dylibx

# Linked libzstd.1.dylib is still listed here even if it doesn't exist

alastair@Alastairs-MacBook-Pro:/usr/local/bin$ otool -L zstd
zstd:
	@rpath/libzstd.1.dylib (compatibility version 1.0.0, current version 1.5.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)

# With the alternative dyld_info tool too

alastair@Alastairs-MacBook-Pro:/usr/local/bin$ dyld_info -dependents zstd
zstd [x86_64]:
    -dependents:
        attributes     load path
                       @rpath/libzstd.1.dylib
                       /usr/lib/libSystem.B.dylib

# But if you run it, it fails

alastair@Alastairs-MacBook-Pro:/usr/local/bin$ ./zstd
dyld[60322]: Library not loaded: '@rpath/libzstd.1.dylib'
  Referenced from: '/usr/local/bin/zstd'
  Reason: tried: './libzstd.1.dylib' (no such file), './libzstd.1.dylib' (no such file), '/usr/local/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file)
Abort trap: 6
```

What's more, the magick.native dylib isn't linked to any non-system shared libraries anyway (the first line is the "internal id" of the dylib file):

```
alastair@macos-12 arm64 % otool -L Magick.Native-Q8-arm64.dll.dylib
Magick.Native-Q8-arm64.dll.dylib:
	@rpath/libMagick.Native-Q8-arm64.dll.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.23.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

If you think we should have some additional tests, let me know.

Thanks!