### PR TITLE
Use shared build libraries script for macos builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
       working-directory: src/ImageMagick
 
     - name: Build libraries
-      run: ../../../build/macos-x64/build.libraries.sh ../../../build/libraries
+      run: ../../../build/shared/build.Libraries.sh ../../../build/libraries macos x64
       working-directory: src/ImageMagick/libraries
 
     - name: Build ImageMagick
@@ -234,7 +234,7 @@ jobs:
       working-directory: src/ImageMagick
 
     - name: Build libraries
-      run: ../../../build/macos-arm64/build.libraries.sh ../../../build/libraries
+      run: ../../../build/shared/build.Libraries.sh ../../../build/libraries macos arm64
       working-directory: src/ImageMagick/libraries
 
     - name: Build ImageMagick

--- a/build/macos-arm64/libraries.sh
+++ b/build/macos-arm64/libraries.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-. $SCRIPT_PATH/settings.sh
-
 $1/build.zlib.sh
 $1/build.xml.sh
 $1/build.png.sh

--- a/build/macos-arm64/settings.sh
+++ b/build/macos-arm64/settings.sh
@@ -1,20 +1,28 @@
 SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 
+# Compiler settings
+if [[ "${DEBUG_BUILD}" ]]; then
+    export FLAGS="-g3 -O0 -fPIC -DDEBUG -arch arm64"
+    export CMAKE_BUILD_TYPE="Debug"
+    export MESON_BUILD_TYPE="debug"
+else
+    export FLAGS="-O3 -fPIC -DNDEBUG -arch arm64"
+    export CMAKE_BUILD_TYPE="Release"
+    export MESON_BUILD_TYPE="release"
+fi
+
 # Shared options
 export PLATFORM=MACOS
 export QUANTUMS=("Q8" "Q16" "Q16-HDRI")
 export EXTENSION="dylib"
-export FLAGS="-O3 -fPIC -arch arm64"
 export STRICT_FLAGS="${FLAGS} -Wall"
 export CONFIGURE="./configure"
 export CONFIGURE_OPTIONS="--host arm64-apple-macos11"
 export CMAKE_COMMAND="cmake"
 export CMAKE_OPTIONS="-DCMAKE_OSX_ARCHITECTURES=arm64"
-export CMAKE_BUILD_TYPE="Release"
 export MAKE="make"
 export MAKEFLAGS="-j$(sysctl -n hw.logicalcpu)"
 export MESON_OPTIONS="--cross-file=$SCRIPT_PATH/cross-compilation.meson"
-export MESON_BUILD_TYPE="release"
 export CPPFLAGS="-I/usr/local/include"
 export LDFLAGS="-L/usr/local/lib"
 export PKG_PATH="/usr/local/lib/pkgconfig"

--- a/build/macos-x64/libraries.sh
+++ b/build/macos-x64/libraries.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-. $SCRIPT_PATH/settings.sh
-
 $1/build.zlib.sh
 $1/build.xml.sh
 $1/build.png.sh

--- a/build/macos-x64/settings.sh
+++ b/build/macos-x64/settings.sh
@@ -1,20 +1,28 @@
 SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 
+# Compiler settings
+if [[ "${DEBUG_BUILD}" ]]; then
+    export FLAGS="-g3 -O0 -fPIC -DDEBUG"
+    export CMAKE_BUILD_TYPE="Debug"
+    export MESON_BUILD_TYPE="debug"
+else
+    export FLAGS="-O3 -fPIC -DNDEBUG"
+    export CMAKE_BUILD_TYPE="Release"
+    export MESON_BUILD_TYPE="release"
+fi
+
 # Shared options
 export PLATFORM=MACOS
 export QUANTUMS=("Q8" "Q16" "Q16-HDRI")
 export EXTENSION="dylib"
-export FLAGS="-O3 -fPIC"
 export STRICT_FLAGS="${FLAGS} -Wall"
 export CONFIGURE="./configure"
 export CONFIGURE_OPTIONS=""
 export CMAKE_COMMAND="cmake"
-export CMAKE_BUILD_TYPE="Release"
 export CMAKE_OPTIONS=""
 export MAKE="make"
 export MAKEFLAGS="-j$(sysctl -n hw.logicalcpu)"
 export MESON_OPTIONS=""
-export MESON_BUILD_TYPE="release"
 export CPPFLAGS="-I/usr/local/include"
 export LDFLAGS="-L/usr/local/lib"
 export PKG_PATH="/usr/local/lib/pkgconfig"


### PR DESCRIPTION
Follow the same format of the build script as introduced in 8807096c5f37cf8c0f0fdc7e2cf396d2f4c317a3

This still results in an exact copy of the libraries.sh script in two locations, the macos x64 and the arm64 folders. Any ideas on how we could keep just one version of this file but still load the relevant settings file for each arch?