### PR TITLE
feat: add custom data to *Stream methods

### DIFF
--- a/src/Magick.Native/MagickImage.c
+++ b/src/Magick.Native/MagickImage.c
@@ -2672,7 +2672,7 @@ MAGICK_NATIVE_EXPORT void MagickImage_WriteFile(Image *instance, const ImageInfo
   MAGICK_NATIVE_SET_EXCEPTION;
 }
 
-MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, const CustomStreamHandler reader, ExceptionInfo **exception)
+MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, const CustomStreamHandler reader, void *data, ExceptionInfo **exception)
 {
   CustomStreamInfo
     *info;
@@ -2683,6 +2683,7 @@ MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *se
   SetCustomStreamSeeker(info, seeker);
   SetCustomStreamTeller(info, teller);
   SetCustomStreamReader(info, reader);
+  SetCustomStreamData(info, data);
   SetImageInfoCustomStream(settings, info);
   ImageToCustomStream(settings, instance, exceptionInfo);
   SetImageInfoCustomStream(settings, (CustomStreamInfo *) NULL);

--- a/src/Magick.Native/MagickImage.c
+++ b/src/Magick.Native/MagickImage.c
@@ -1980,7 +1980,7 @@ MAGICK_NATIVE_EXPORT Image *MagickImage_ReadPixels(const size_t width, const siz
   return image;
 }
 
-MAGICK_NATIVE_EXPORT Image *MagickImage_ReadStream(ImageInfo *settings, const CustomStreamHandler reader, const CustomStreamSeeker seeker, const CustomStreamTeller teller, ExceptionInfo **exception)
+MAGICK_NATIVE_EXPORT Image *MagickImage_ReadStream(ImageInfo *settings, const CustomStreamHandler reader, const CustomStreamSeeker seeker, const CustomStreamTeller teller, void *data, ExceptionInfo **exception)
 {
   Image
     *image;
@@ -1993,6 +1993,7 @@ MAGICK_NATIVE_EXPORT Image *MagickImage_ReadStream(ImageInfo *settings, const Cu
   SetCustomStreamReader(info, reader);
   SetCustomStreamSeeker(info, seeker);
   SetCustomStreamTeller(info, teller);
+  SetCustomStreamData(info, data);
   SetImageInfoCustomStream(settings, info);
   image = CustomStreamToImage(settings, exceptionInfo);
   SetImageInfoCustomStream(settings, (CustomStreamInfo *) NULL);

--- a/src/Magick.Native/MagickImage.h
+++ b/src/Magick.Native/MagickImage.h
@@ -392,7 +392,7 @@ MAGICK_NATIVE_EXPORT Image *MagickImage_ReadFile(const ImageInfo *, ExceptionInf
 
 MAGICK_NATIVE_EXPORT Image *MagickImage_ReadPixels(const size_t, const size_t, const char *, const size_t, const void *, const size_t, ExceptionInfo **);
 
-MAGICK_NATIVE_EXPORT Image *MagickImage_ReadStream(ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, ExceptionInfo **);
+MAGICK_NATIVE_EXPORT Image *MagickImage_ReadStream(ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, void *, ExceptionInfo **);
 
 MAGICK_NATIVE_EXPORT void MagickImage_RegionMask(Image *, const RectangleInfo *, ExceptionInfo **);
 

--- a/src/Magick.Native/MagickImage.h
+++ b/src/Magick.Native/MagickImage.h
@@ -528,7 +528,7 @@ MAGICK_NATIVE_EXPORT unsigned char *MagickImage_WriteBlob(Image *, const ImageIn
 
 MAGICK_NATIVE_EXPORT void MagickImage_WriteFile(Image *, const ImageInfo *, ExceptionInfo **);
 
-MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, const CustomStreamHandler, ExceptionInfo **);
+MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, const CustomStreamHandler, void *, ExceptionInfo **);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/src/Magick.Native/MagickImageCollection.c
+++ b/src/Magick.Native/MagickImageCollection.c
@@ -228,7 +228,7 @@ MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadFile(ImageInfo *settings, 
   return images;
 }
 
-MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadStream(ImageInfo *settings, const CustomStreamHandler reader, const CustomStreamSeeker seeker, const CustomStreamTeller teller, ExceptionInfo **exception)
+MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadStream(ImageInfo *settings, const CustomStreamHandler reader, const CustomStreamSeeker seeker, const CustomStreamTeller teller, void *data, ExceptionInfo **exception)
 {
   Image
     *images;
@@ -241,6 +241,7 @@ MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadStream(ImageInfo *settings
   SetCustomStreamReader(info, reader);
   SetCustomStreamSeeker(info, seeker);
   SetCustomStreamTeller(info, teller);
+  SetCustomStreamData(info, data);
   SetImageInfoCustomStream(settings, info);
   images = CustomStreamToImage(settings, exceptionInfo);
   SetImageInfoCustomStream(settings, (CustomStreamInfo *) NULL);
@@ -267,7 +268,7 @@ MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteFile(Image *image, const Im
   MAGICK_NATIVE_SET_EXCEPTION;
 }
 
-MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteStream(Image *image, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, const CustomStreamHandler reader, ExceptionInfo **exception)
+MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteStream(Image *image, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, const CustomStreamHandler reader, void *data, ExceptionInfo **exception)
 {
   CustomStreamInfo
     *info;
@@ -278,6 +279,7 @@ MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteStream(Image *image, ImageI
   SetCustomStreamSeeker(info, seeker);
   SetCustomStreamTeller(info, teller);
   SetCustomStreamReader(info, reader);
+  SetCustomStreamData(info, data);
   SetImageInfoCustomStream(settings, info);
   ImagesToCustomStream(settings, image, exceptionInfo);
   SetImageInfoCustomStream(settings, (CustomStreamInfo *) NULL);

--- a/src/Magick.Native/MagickImageCollection.h
+++ b/src/Magick.Native/MagickImageCollection.h
@@ -44,13 +44,13 @@ MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadBlob(const ImageInfo *, co
 
 MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadFile(ImageInfo *, ExceptionInfo **);
 
-MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadStream(ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, ExceptionInfo **);
+MAGICK_NATIVE_EXPORT Image *MagickImageCollection_ReadStream(ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, void *, ExceptionInfo **);
 
 MAGICK_NATIVE_EXPORT Image *MagickImageCollection_Smush(const Image *, const ssize_t, const MagickBooleanType, ExceptionInfo **);
 
 MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteFile(Image *, const ImageInfo *, ExceptionInfo **);
 
-MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, const CustomStreamHandler, ExceptionInfo **);
+MAGICK_NATIVE_EXPORT void MagickImageCollection_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, const CustomStreamHandler, void *, ExceptionInfo **);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }


### PR DESCRIPTION
:wave: 

This PR add a call to `MagickImage_ReadStream`.

I need it to pass custom data with the stream, so I can find the original stream in the callback.

Unlike C#, [Kotlin the callback can't capture context](https://kotlinlang.org/docs/native-c-interop.html#callbacks), so it need the usage of global objects.
In other words, there is no equivalent of Magick.NET `ReadWriteStreamDelegate`.

Quoting from previous link:

> Often C APIs allow passing some user data to callbacks. Such data is usually provided by the user when configuring the callback. It is passed to some C function (or written to the struct) as e.g. void*

If I understand documentation correctly, this is exactly what ImageMagick do:

https://github.com/ImageMagick/ImageMagick/blob/738d434e105c42d8612dd0af90a73d0266f43bd0/MagickCore/blob.c#L896-L897

I've not tested it and don't know if it will works... It's totally new things for me.

I guess I could just do the same calls as `MagickImage_ReadStream` in same order to test it?

Edit: I figure out if it's the right way to do things, I will probably the same feature on all functions that support "custom" data