### PR TITLE
fix: remove useless reader for MagickImage_WriteStream

### DIFF
--- a/src/Magick.Native/MagickImage.c
+++ b/src/Magick.Native/MagickImage.c
@@ -2674,7 +2674,7 @@ MAGICK_NATIVE_EXPORT void MagickImage_WriteFile(Image *instance, const ImageInfo
   MAGICK_NATIVE_SET_EXCEPTION;
 }
 
-MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, const CustomStreamHandler reader, void *data, ExceptionInfo **exception)
+MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *settings, const CustomStreamHandler writer, const CustomStreamSeeker seeker, const CustomStreamTeller teller, void *data, ExceptionInfo **exception)
 {
   CustomStreamInfo
     *info;
@@ -2684,7 +2684,6 @@ MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *instance, ImageInfo *se
   SetCustomStreamWriter(info, writer);
   SetCustomStreamSeeker(info, seeker);
   SetCustomStreamTeller(info, teller);
-  SetCustomStreamReader(info, reader);
   SetCustomStreamData(info, data);
   SetImageInfoCustomStream(settings, info);
   ImageToCustomStream(settings, instance, exceptionInfo);

--- a/src/Magick.Native/MagickImage.h
+++ b/src/Magick.Native/MagickImage.h
@@ -528,7 +528,7 @@ MAGICK_NATIVE_EXPORT unsigned char *MagickImage_WriteBlob(Image *, const ImageIn
 
 MAGICK_NATIVE_EXPORT void MagickImage_WriteFile(Image *, const ImageInfo *, ExceptionInfo **);
 
-MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, const CustomStreamHandler, void *, ExceptionInfo **);
+MAGICK_NATIVE_EXPORT void MagickImage_WriteStream(Image *, ImageInfo *, const CustomStreamHandler, const CustomStreamSeeker, const CustomStreamTeller, void *, ExceptionInfo **);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }


### PR DESCRIPTION
:wave:

If I'm right, ImageMagick doesn't use a reader for in function `ImageToCustomStream` : https://github.com/ImageMagick/ImageMagick/blob/d652d274ac95b30a84e51e07332ffe235efcc569/MagickCore/blob.c#L2188-L2304

Therefore, there is no need of a reader callback.

Regards.